### PR TITLE
integrate with az and git extensions for smart-defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.3-palette",
       "license": "MIT",
       "dependencies": {
+        "@azure/arm-resources": "^5.0.1",
         "@azure/arm-subscriptions": "^5.0.1",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-nodeauth": "^3.1.1",
@@ -57,6 +58,28 @@
       }
     },
     "node_modules/@azure/abort-controller/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@azure/arm-resources": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
+      "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.2.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/arm-resources/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
@@ -5937,6 +5960,27 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
       "requires": {
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@azure/arm-resources": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
+      "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.2.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
         "tslib": "^2.2.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "test": "node ./out/test/runTest.js"
   },
   "extensionDependencies": [
-    "ms-vscode.azure-account"
+    "ms-vscode.azure-account",
+    "vscode.git"
   ],
   "devDependencies": {
     "@types/download": "^8.0.1",
@@ -129,6 +130,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
+    "@azure/arm-resources": "^5.0.1",
     "@azure/arm-subscriptions": "^5.0.1",
     "@azure/ms-rest-azure-env": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^3.1.1",

--- a/src/commands/runDraftTool/runDraftSetupGH.ts
+++ b/src/commands/runDraftTool/runDraftSetupGH.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import {QuickPickItem} from 'vscode';
 import { longRunning } from '../../utils/host';
 import { ensureDraftBinary } from './helper/runDraftHelper';
 import { window, ExtensionContext } from 'vscode';
@@ -6,20 +7,27 @@ import { buildSetupGHCommand } from './helper/draftCommandBuilder';
 import { runDraftCommand } from './helper/runDraftHelper';
 import { reporter } from './../../utils/reporter';
 import { MultiStepInput, shouldResume } from './model/multiStep';
+import { AzApi } from '../../utils/az';
+import { SubscriptionClient, Subscription } from "@azure/arm-subscriptions";
+import { ResourceGroup } from '@azure/arm-resources';
+import { basename } from 'path';
+import { API as GitAPI, GitExtension, APIState } from '../../utils/git';
 
 export default async function runDraftSetupGH(
     _context: vscode.ExtensionContext,
-    destination: string
+    destination: string,
+	az: AzApi,
+	git: GitAPI
 ): Promise<void> {
     const downladResult = await longRunning(`Downloading Draft.`, () => ensureDraftBinary());
     if (!downladResult) {
         return undefined;
     }
 
-    multiStepInput(_context, destination);
+    multiStepInput(_context, destination,az,git);
 }
 
-async function multiStepInput(context: ExtensionContext, destination: string) {
+async function multiStepInput(context: ExtensionContext, destination: string, az: AzApi, git: GitAPI) {
     const title = 'Configure GitHub OpenID Connect';
 
 	interface State {
@@ -32,46 +40,92 @@ async function multiStepInput(context: ExtensionContext, destination: string) {
         ghRepo: string;
 	}
 
+    const defaultAppName = basename(destination);
+
+	const filteredRepositories = git.repositories.filter(r => r.rootUri.fsPath === destination);
+	const firstFiltered = filteredRepositories[0];
+	const firstRemote = firstFiltered && firstFiltered.state.remotes[0];
+	const firstPushUrl = firstRemote && firstRemote.pushUrl;
+	const defaultRepo = firstPushUrl || 'https://github.com/username/repo';
+
 	async function collectInputs() {
-		const state = {} as Partial<State>;
-		await MultiStepInput.run(input => inputAppName(input, state, 1));
+		const state = {
+			appName: defaultAppName,
+			ghRepo: defaultRepo,
+		} as Partial<State>;
+		await MultiStepInput.run(input => inputSubscriptionID(input, state, 1));
 		return state as State;
 	}
 
     const totalSteps = 4;
+
+	async function inputSubscriptionID(input: MultiStepInput, state: Partial<State>, step: number) {
+		const getSubscriptionsResult = await az.getSubscriptions();
+		if (!getSubscriptionsResult.succeeded) {
+			window.showErrorMessage(`Failed to get Subscriptions: ${getSubscriptionsResult}`);
+			return;
+		}
+		const subscriptions: Subscription[] = getSubscriptionsResult.result;
+
+		console.log(subscriptions);
+		
+		const items = subscriptions.map((subscription) => {
+			return {
+				label: `${subscription.displayName}`,
+				description: subscription.subscriptionId,
+			};
+		});
+		
+		const selectedItem = await input.showQuickPick({
+			title,
+			step,
+			totalSteps,
+			placeholder: 'Select an Azure Subscription',
+			items,
+			activeItem: typeof state.subscriptionId !== 'string' ? state.subscriptionId : undefined,
+			shouldResume
+		});
+
+		const selectedSubscription = subscriptions.find((subscription) => subscription.subscriptionId === selectedItem.description) as Subscription;
+		state.subscriptionId = selectedSubscription.subscriptionId;
+
+		return (input: MultiStepInput) => inputResourceGroup(input, state, step + 1, az);
+	}
+	
+	async function inputResourceGroup(input: MultiStepInput, state: Partial<State>, step: number,az: AzApi) {
+		const getResourceGroupResult = await az.getResourceGroups(state.subscriptionId as string);
+		if (!getResourceGroupResult.succeeded) {
+			window.showErrorMessage(`Failed to get ResourceGroups: ${getResourceGroupResult}`);
+			return;
+		}
+		const resourceGroups: ResourceGroup[] = getResourceGroupResult.result;
+		
+		const items: QuickPickItem[] = resourceGroups.map((resourceGroup: ResourceGroup) => {
+			return {
+				label: `${resourceGroup.name}`,
+				description: resourceGroup.location,
+			};
+		});
+
+		const selectedItem = await input.showQuickPick({
+			title,
+			step,
+			totalSteps,
+			placeholder: 'Select an Azure Resource Group',
+			items,
+			activeItem: typeof state.resourceGroup !== 'string' ? state.resourceGroup : undefined,
+			shouldResume
+		});
+        return (input: MultiStepInput) => inputAppName(input, state, step + 1);
+	}
+
 	async function inputAppName(input: MultiStepInput, state: Partial<State>, step: number) {
 		state.appName = await input.showInputBox({
 			title,
 			step: step,
 			totalSteps: totalSteps,
 			value: typeof state.appName === 'string' ? state.appName : '',
-			prompt: 'Enter app registration name',
-			validate: async() => undefined,
-			shouldResume: shouldResume
-		});
-        return (input: MultiStepInput) => inputSubscritptionId(input, state, step + 1);
-	}
-
-	async function inputSubscritptionId(input: MultiStepInput, state: Partial<State>, step: number) {
-		state.subscriptionId = await input.showInputBox({
-			title,
-			step: step,
-			totalSteps: totalSteps,
-			value: typeof state.subscriptionId === 'string' ? state.subscriptionId : '',
-			prompt: 'Enter Azure subscription ID',
-			validate: async() => undefined,
-			shouldResume: shouldResume
-		});
-		return (input: MultiStepInput) => inputresourceGroup(input, state, step + 1);
-	}
-
-    async function inputresourceGroup(input: MultiStepInput, state: Partial<State>, step: number) {
-		state.resourceGroup = await input.showInputBox({
-			title,
-			step: step,
-			totalSteps: totalSteps,
-			value: typeof state.resourceGroup === 'string' ? state.resourceGroup : '',
-			prompt: 'Enter Azure resource group name',
+			prompt: 'Azure Active Directory application name (e.g. myapp-github-actions)',
 			validate: async() => undefined,
 			shouldResume: shouldResume
 		});
@@ -84,7 +138,7 @@ async function multiStepInput(context: ExtensionContext, destination: string) {
 			step: step,
 			totalSteps: totalSteps,
 			value: typeof state.ghRepo === 'string' ? state.ghRepo : '',
-			prompt: 'Enter GitHub repository:',
+			prompt: 'Enter GitHub repository (e.g. https://github.com/contoso/myapp)',
 			validate: async() => undefined,
 			shouldResume: shouldResume
 		});

--- a/src/commands/runDraftTool/runDraftSetupGH.ts
+++ b/src/commands/runDraftTool/runDraftSetupGH.ts
@@ -11,7 +11,7 @@ import { AzApi } from '../../utils/az';
 import { SubscriptionClient, Subscription } from "@azure/arm-subscriptions";
 import { ResourceGroup } from '@azure/arm-resources';
 import { basename } from 'path';
-import { API as GitAPI, GitExtension, APIState } from '../../utils/git';
+import { API as GitAPI } from '../../utils/git';
 
 export default async function runDraftSetupGH(
     _context: vscode.ExtensionContext,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { Reporter, reporter } from './utils/reporter';
 import type { AzureExtensionApiProvider } from '@microsoft/vscode-azext-utils/api';
 import { AzureAccountExtensionApi } from './utils/azAccount';
 import { Az, AzApi } from './utils/az';
+import { API as GitAPI, GitExtension, APIState } from './utils/git';
 
 
 // this method is called when your extension is activated
@@ -30,36 +31,33 @@ export function activate(context: vscode.ExtensionContext) {
 	// TODO: pass this into any command function that needs to interact with azure
 	const az: AzApi = new Az(azureAccount);
 
+	const git:GitAPI = <GitAPI>vscode.extensions.getExtension('vscode.git')!.exports.getAPI(1);
+
 	let disposableDockerfile = vscode.commands.registerCommand('aks-draft-extension.runDraftDockerfile', async (folder) => {
 		if (reporter) {
             reporter.sendTelemetryEvent("command", { command: 'aks-draft-extension.runDraftDockerfile' });
         }
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
 		runDraftDockerfile(context, currentWorkspace.uri.fsPath);
 	});
+
 	let disposableSetupGH = vscode.commands.registerCommand('aks-draft-extension.runDraftSetupGH', async (folder) => {
 		if (reporter) {
             reporter.sendTelemetryEvent("command", { command: 'aks-draft-extension.runDraftSetupGH' });
         }
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		runDraftSetupGH(context, currentWorkspace.uri.fsPath);
+		runDraftSetupGH(context, currentWorkspace.uri.fsPath,az,git);
 	});
+
 	let disposableGenerateWorkflow = vscode.commands.registerCommand('aks-draft-extension.runDraftGenerateWorkflow', async (folder) => {
 		if (reporter) {
             reporter.sendTelemetryEvent("command", { command: 'aks-draft-extension.runDraftGenerateWorkflow' });
         }
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
 		runDraftGenerateWorkflow(context, vscode.Uri.parse(folder).fsPath);
 	});
+
 	let disposableUpdate = vscode.commands.registerCommand('aks-draft-extension.runDraftUpdate', async (folder) => {
 		if (reporter) {
             reporter.sendTelemetryEvent("command", { command: 'aks-draft-extension.runDraftUpdate' });
         }
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
 		runDraftUpdate(context, vscode.Uri.parse(folder).fsPath);
 	});
 

--- a/src/utils/az.ts
+++ b/src/utils/az.ts
@@ -2,9 +2,12 @@ import { AzureAccountExtensionApi } from "./azAccount";
 import { commands } from "vscode";
 import { Errorable } from "./errorable";
 import { SubscriptionClient, Subscription } from "@azure/arm-subscriptions";
+import { ResourceManagementClient, ResourceGroup } from '@azure/arm-resources';
+import { longRunning } from "./host";
 
 export interface AzApi {
   getSubscriptions(): Promise<Errorable<Subscription[]>>;
+  getResourceGroups(subscriptionId: string): Promise<Errorable<ResourceGroup[]>>;
 }
 
 // TODO: add any needed az interactions
@@ -13,12 +16,20 @@ export interface AzApi {
 export class Az {
   constructor(private azAccount: AzureAccountExtensionApi) {}
 
-  async getSubscriptions(): Promise<Errorable<Subscription[]>> {
+  async checkLoginAndFilters(): Promise<Errorable<void>> {
     if (!(await this.azAccount.waitForLogin())) {
       commands.executeCommand("azure-account.askForLogin");
       return { succeeded: false, error: "failed to login" };
     }
     await this.azAccount.waitForFilters();
+    return { succeeded: true, result: undefined };
+  }
+
+  async getSubscriptions(): Promise<Errorable<Subscription[]>> {
+    const loginResult = await this.checkLoginAndFilters();
+    if (!loginResult.succeeded) {
+      return loginResult;
+    }
 
     const subs: Subscription[] = [];
     for (const session of this.azAccount.sessions) {
@@ -26,14 +37,48 @@ export class Az {
       const subscriptionClient = new SubscriptionClient(credentials);
 
       // TODO: turn this logic into a generic
-      const subscriptionPages = subscriptionClient.subscriptions
-        .list()
-        .byPage();
-      for await (const page of subscriptionPages) {
-        subs.push(...page);
-      }
+      const downloadResult = await longRunning(`Fetching Azure Subscriptions`, async () => {
+
+        const subscriptionPages = subscriptionClient.subscriptions
+            .list()
+            .byPage();
+
+        for await (const page of subscriptionPages) {
+          subs.push(...page);
+        }
+        return;
+      });
     }
 
     return { succeeded: true, result: subs };
   }
+
+  async getResourceGroups(subscriptionID: string): Promise<Errorable<ResourceGroup[]>> {
+    const loginResult = await this.checkLoginAndFilters();
+    if (!loginResult.succeeded) {
+      return loginResult;
+    } 
+    const rgs: ResourceGroup[] = [];
+    for (const session of this.azAccount.sessions) {
+      const credentials = session.credentials2;
+      const resourceManagementClient: ResourceManagementClient = new ResourceManagementClient(credentials, subscriptionID);
+
+      resourceManagementClient.resourceGroups;
+      // TODO: turn this logic into a generic
+      const resourceGroups = await longRunning(`Fetching Resource Groups`, async () => {
+      
+        const resourceGroupPages = resourceManagementClient.resourceGroups 
+            .list()
+            .byPage();
+
+        for await (const page of resourceGroupPages) {
+          rgs.push(...page);
+        }
+        return;
+      });
+    }
+
+    return { succeeded: true, result: rgs };
+  }
+
 }

--- a/src/utils/git.d.ts
+++ b/src/utils/git.d.ts
@@ -1,0 +1,355 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Uri, Event, Disposable, ProviderResult, Command } from 'vscode';
+export { ProviderResult } from 'vscode';
+
+export interface Git {
+	readonly path: string;
+}
+
+export interface InputBox {
+	value: string;
+}
+
+export const enum ForcePushMode {
+	Force,
+	ForceWithLease
+}
+
+export const enum RefType {
+	Head,
+	RemoteHead,
+	Tag
+}
+
+export interface Ref {
+	readonly type: RefType;
+	readonly name?: string;
+	readonly commit?: string;
+	readonly remote?: string;
+}
+
+export interface UpstreamRef {
+	readonly remote: string;
+	readonly name: string;
+}
+
+export interface Branch extends Ref {
+	readonly upstream?: UpstreamRef;
+	readonly ahead?: number;
+	readonly behind?: number;
+}
+
+export interface Commit {
+	readonly hash: string;
+	readonly message: string;
+	readonly parents: string[];
+	readonly authorDate?: Date;
+	readonly authorName?: string;
+	readonly authorEmail?: string;
+	readonly commitDate?: Date;
+}
+
+export interface Submodule {
+	readonly name: string;
+	readonly path: string;
+	readonly url: string;
+}
+
+export interface Remote {
+	readonly name: string;
+	readonly fetchUrl?: string;
+	readonly pushUrl?: string;
+	readonly isReadOnly: boolean;
+}
+
+export const enum Status {
+	INDEX_MODIFIED,
+	INDEX_ADDED,
+	INDEX_DELETED,
+	INDEX_RENAMED,
+	INDEX_COPIED,
+
+	MODIFIED,
+	DELETED,
+	UNTRACKED,
+	IGNORED,
+	INTENT_TO_ADD,
+
+	ADDED_BY_US,
+	ADDED_BY_THEM,
+	DELETED_BY_US,
+	DELETED_BY_THEM,
+	BOTH_ADDED,
+	BOTH_DELETED,
+	BOTH_MODIFIED
+}
+
+export interface Change {
+
+	/**
+	 * Returns either `originalUri` or `renameUri`, depending
+	 * on whether this change is a rename change. When
+	 * in doubt always use `uri` over the other two alternatives.
+	 */
+	readonly uri: Uri;
+	readonly originalUri: Uri;
+	readonly renameUri: Uri | undefined;
+	readonly status: Status;
+}
+
+export interface RepositoryState {
+	readonly HEAD: Branch | undefined;
+	readonly refs: Ref[];
+	readonly remotes: Remote[];
+	readonly submodules: Submodule[];
+	readonly rebaseCommit: Commit | undefined;
+
+	readonly mergeChanges: Change[];
+	readonly indexChanges: Change[];
+	readonly workingTreeChanges: Change[];
+
+	readonly onDidChange: Event<void>;
+}
+
+export interface RepositoryUIState {
+	readonly selected: boolean;
+	readonly onDidChange: Event<void>;
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+	/** Max number of log entries to retrieve. If not specified, the default is 32. */
+	readonly maxEntries?: number;
+	readonly path?: string;
+}
+
+export interface CommitOptions {
+	all?: boolean | 'tracked';
+	amend?: boolean;
+	signoff?: boolean;
+	signCommit?: boolean;
+	empty?: boolean;
+	noVerify?: boolean;
+	requireUserConfig?: boolean;
+	useEditor?: boolean;
+	verbose?: boolean;
+	/**
+	 * string    - execute the specified command after the commit operation
+	 * undefined - execute the command specified in git.postCommitCommand
+	 *             after the commit operation
+	 * null      - do not execute any command after the commit operation
+	 */
+	postCommitCommand?: string | null;
+}
+
+export interface FetchOptions {
+	remote?: string;
+	ref?: string;
+	all?: boolean;
+	prune?: boolean;
+	depth?: number;
+}
+
+export interface BranchQuery {
+	readonly remote?: boolean;
+	readonly pattern?: string;
+	readonly count?: number;
+	readonly contains?: string;
+}
+
+export interface Repository {
+
+	readonly rootUri: Uri;
+	readonly inputBox: InputBox;
+	readonly state: RepositoryState;
+	readonly ui: RepositoryUIState;
+
+	getConfigs(): Promise<{ key: string; value: string; }[]>;
+	getConfig(key: string): Promise<string>;
+	setConfig(key: string, value: string): Promise<string>;
+	getGlobalConfig(key: string): Promise<string>;
+
+	getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>;
+	detectObjectType(object: string): Promise<{ mimetype: string, encoding?: string }>;
+	buffer(ref: string, path: string): Promise<Buffer>;
+	show(ref: string, path: string): Promise<string>;
+	getCommit(ref: string): Promise<Commit>;
+
+	add(paths: string[]): Promise<void>;
+	revert(paths: string[]): Promise<void>;
+	clean(paths: string[]): Promise<void>;
+
+	apply(patch: string, reverse?: boolean): Promise<void>;
+	diff(cached?: boolean): Promise<string>;
+	diffWithHEAD(): Promise<Change[]>;
+	diffWithHEAD(path: string): Promise<string>;
+	diffWith(ref: string): Promise<Change[]>;
+	diffWith(ref: string, path: string): Promise<string>;
+	diffIndexWithHEAD(): Promise<Change[]>;
+	diffIndexWithHEAD(path: string): Promise<string>;
+	diffIndexWith(ref: string): Promise<Change[]>;
+	diffIndexWith(ref: string, path: string): Promise<string>;
+	diffBlobs(object1: string, object2: string): Promise<string>;
+	diffBetween(ref1: string, ref2: string): Promise<Change[]>;
+	diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
+
+	hashObject(data: string): Promise<string>;
+
+	createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
+	deleteBranch(name: string, force?: boolean): Promise<void>;
+	getBranch(name: string): Promise<Branch>;
+	getBranches(query: BranchQuery): Promise<Ref[]>;
+	setBranchUpstream(name: string, upstream: string): Promise<void>;
+
+	getMergeBase(ref1: string, ref2: string): Promise<string>;
+
+	tag(name: string, upstream: string): Promise<void>;
+	deleteTag(name: string): Promise<void>;
+
+	status(): Promise<void>;
+	checkout(treeish: string): Promise<void>;
+
+	addRemote(name: string, url: string): Promise<void>;
+	removeRemote(name: string): Promise<void>;
+	renameRemote(name: string, newName: string): Promise<void>;
+
+	fetch(options?: FetchOptions): Promise<void>;
+	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
+	pull(unshallow?: boolean): Promise<void>;
+	push(remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode): Promise<void>;
+
+	blame(path: string): Promise<string>;
+	log(options?: LogOptions): Promise<Commit[]>;
+
+	commit(message: string, opts?: CommitOptions): Promise<void>;
+}
+
+export interface RemoteSource {
+	readonly name: string;
+	readonly description?: string;
+	readonly url: string | string[];
+}
+
+export interface RemoteSourceProvider {
+	readonly name: string;
+	readonly icon?: string; // codicon name
+	readonly supportsQuery?: boolean;
+	getRemoteSources(query?: string): ProviderResult<RemoteSource[]>;
+	getBranches?(url: string): ProviderResult<string[]>;
+	publishRepository?(repository: Repository): Promise<void>;
+}
+
+export interface RemoteSourcePublisher {
+	readonly name: string;
+	readonly icon?: string; // codicon name
+	publishRepository(repository: Repository): Promise<void>;
+}
+
+export interface Credentials {
+	readonly username: string;
+	readonly password: string;
+}
+
+export interface CredentialsProvider {
+	getCredentials(host: Uri): ProviderResult<Credentials>;
+}
+
+export interface PostCommitCommandsProvider {
+	getCommands(repository: Repository): Command[];
+}
+
+export interface PushErrorHandler {
+	handlePushError(repository: Repository, remote: Remote, refspec: string, error: Error & { gitErrorCode: GitErrorCodes }): Promise<boolean>;
+}
+
+export type APIState = 'uninitialized' | 'initialized';
+
+export interface PublishEvent {
+	repository: Repository;
+	branch?: string;
+}
+
+export interface API {
+	readonly state: APIState;
+	readonly onDidChangeState: Event<APIState>;
+	readonly onDidPublish: Event<PublishEvent>;
+	readonly git: Git;
+	readonly repositories: Repository[];
+	readonly onDidOpenRepository: Event<Repository>;
+	readonly onDidCloseRepository: Event<Repository>;
+
+	toGitUri(uri: Uri, ref: string): Uri;
+	getRepository(uri: Uri): Repository | null;
+	init(root: Uri): Promise<Repository | null>;
+	openRepository(root: Uri): Promise<Repository | null>
+
+	registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;
+	registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
+	registerCredentialsProvider(provider: CredentialsProvider): Disposable;
+	registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): Disposable;
+	registerPushErrorHandler(handler: PushErrorHandler): Disposable;
+}
+
+export interface GitExtension {
+
+	readonly enabled: boolean;
+	readonly onDidChangeEnablement: Event<boolean>;
+
+	/**
+	 * Returns a specific API version.
+	 *
+	 * Throws error if git extension is disabled. You can listen to the
+	 * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
+	 * to know when the extension becomes enabled/disabled.
+	 *
+	 * @param version Version number.
+	 * @returns API instance
+	 */
+	getAPI(version: 1): API;
+}
+
+export const enum GitErrorCodes {
+	BadConfigFile = 'BadConfigFile',
+	AuthenticationFailed = 'AuthenticationFailed',
+	NoUserNameConfigured = 'NoUserNameConfigured',
+	NoUserEmailConfigured = 'NoUserEmailConfigured',
+	NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+	NotAGitRepository = 'NotAGitRepository',
+	NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+	Conflict = 'Conflict',
+	StashConflict = 'StashConflict',
+	UnmergedChanges = 'UnmergedChanges',
+	PushRejected = 'PushRejected',
+	RemoteConnectionError = 'RemoteConnectionError',
+	DirtyWorkTree = 'DirtyWorkTree',
+	CantOpenResource = 'CantOpenResource',
+	GitNotFound = 'GitNotFound',
+	CantCreatePipe = 'CantCreatePipe',
+	PermissionDenied = 'PermissionDenied',
+	CantAccessRemote = 'CantAccessRemote',
+	RepositoryNotFound = 'RepositoryNotFound',
+	RepositoryIsLocked = 'RepositoryIsLocked',
+	BranchNotFullyMerged = 'BranchNotFullyMerged',
+	NoRemoteReference = 'NoRemoteReference',
+	InvalidBranchName = 'InvalidBranchName',
+	BranchAlreadyExists = 'BranchAlreadyExists',
+	NoLocalChanges = 'NoLocalChanges',
+	NoStashFound = 'NoStashFound',
+	LocalChangesOverwritten = 'LocalChangesOverwritten',
+	NoUpstreamBranch = 'NoUpstreamBranch',
+	IsInSubmodule = 'IsInSubmodule',
+	WrongCase = 'WrongCase',
+	CantLockRef = 'CantLockRef',
+	CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+	PatchDoesNotApply = 'PatchDoesNotApply',
+	NoPathFound = 'NoPathFound',
+	UnknownPath = 'UnknownPath',
+	EmptyCommitMessage = 'EmptyCommitMessage',
+	BranchFastForwardRejected = 'BranchFastForwardRejected'
+}


### PR DESCRIPTION
# Description

- Re-order inputs for the `Configure GitHub OpenID Connect` to match spec.
- Source smart-defaults in the following ways
  - Subscription - use az vscode extension to query currently logged in user subscriptions and searchable by both name and id
  - Resource Group - query resource groups within the subscription specified in step 1 using the az vscode extension
  - App name - set default to use name of the root of the active workspace
  - Git Repo - use git vscode extension to retrieve the first remote repository push URL linked to the current repo


Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- Manual testing of the command pallet

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

