### PR TITLE
increase draft binary download timeout and fix typo

### DIFF
--- a/src/test/suite/utils/languages.test.ts
+++ b/src/test/suite/utils/languages.test.ts
@@ -15,11 +15,13 @@ import {ensureDraftBinary} from '../../../commands/runDraftTool/helper/runDraftH
 
 suite('Languages Test Suite', () => {
    before(async function () {
-      this.timeout(5000);
-      await getAsyncResult(ensureDraftBinary());
+      this.timeout(10000);
+      if (failed(await ensureDraftBinary())) {
+         throw new Error('Failed to ensure draft binary');
+      }
    });
 
-   test('languages are retrieve from draft info without error', async () => {
+   test('languages are retrieved from draft info without error', async () => {
       const languages = await getAsyncResult(getDraftLanguages());
 
       assert.doesNotThrow(getDraftLanguages);


### PR DESCRIPTION
# Description

increase the allowable time to download the draft binary in the smoke tests to account for potentially slow GitHub runner internet download speed.

also correct a typo

## Type of change

Please delete options that are not relevant.

-  [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-  [x] My code follows the style guidelines of this project
-  [x] I have performed a self-review of my code
-  [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
-  [x] My changes generate no new warnings
-  [x] I have added tests that prove my fix is effective or that my feature works
-  [x] New and existing unit tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules
