### PR TITLE
bump draft to v0.0.30 and add `IMAGETAG` field for draft create

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
          "properties": {
             "aks.draft.releaseTag": {
                "type": "string",
-               "default": "v0.0.27",
+               "default": "v0.0.30",
                "title": "Draft repository release tag",
                "description": "Release tag for the stable Draft tool release."
             }

--- a/src/commands/runDraftTool/helper/draftCommandBuilder.ts
+++ b/src/commands/runDraftTool/helper/draftCommandBuilder.ts
@@ -34,7 +34,8 @@ export function buildCreateConfig(
    workflow: string,
    languageVersion: string,
    namespace: string,
-   imageName: string
+   imageName: string,
+   imageTag: string
 ): string {
    let data = {
       deployType: workflow,
@@ -83,6 +84,12 @@ export function buildCreateConfig(
       });
    }
 
+   if (imageTag.length > 0) {
+      data.deployVariables.push({
+         name: 'IMAGETAG',
+         value: imageTag
+      });
+   }
    const tempFile = fileSync({postfix: '.yaml'});
    fs.writeFileSync(tempFile.name, stringify(data));
 

--- a/src/commands/runDraftTool/helper/languages.ts
+++ b/src/commands/runDraftTool/helper/languages.ts
@@ -65,39 +65,3 @@ export async function getDraftLanguages(): Promise<Errorable<DraftLanguage[]>> {
       result: infoLanguages
    };
 }
-export const draftLanguages: DraftLanguage[] = [
-   {id: 'clojure', name: 'Clojure', versions: ['8-jdk-alpine']},
-   {id: 'csharp', name: 'C#', versions: ['6.0', '5.0', '4.0', '3.1']},
-   {id: 'erlang', name: 'Erlang', versions: ['3.15']},
-   {id: 'go', name: 'Go', versions: ['1.19', '1.18', '1.17', '1.16']},
-   {
-      id: 'gomodule',
-      name: 'Go Modules',
-      versions: ['1.19', '1.18', '1.17', '1.16']
-   },
-   {id: 'java', name: 'Java', versions: ['11-jre-slim']},
-   {id: 'gradle', name: 'Gradle', versions: ['11-jre-slim']},
-   {
-      id: 'javascript',
-      name: 'JavaScript',
-      versions: ['14.15.4', '12.16.3', '10.16.3']
-   },
-   {
-      id: 'php',
-      name: 'PHP',
-      versions: [
-         '7.4-apache',
-         '7.4-fpm',
-         '7.4-cli',
-         '7.3-apache',
-         '7.3-fpm',
-         '7.3-cli',
-         '7.2-apache',
-         '7.2-fpm',
-         '7.2-cli'
-      ]
-   },
-   {id: 'python', name: 'Python', versions: ['3.8', '3.7', '3.6']},
-   {id: 'rust', name: 'Rust', versions: ['1.42.0']},
-   {id: 'swift', name: 'Swift', versions: ['5.5', '5.4', '5.3', '5.2']}
-];

--- a/src/commands/runDraftTool/helper/runDraftHelper.ts
+++ b/src/commands/runDraftTool/helper/runDraftHelper.ts
@@ -58,7 +58,6 @@ export async function ensureDraftBinary(): Promise<Errorable<null>> {
       draftDownloadUrl,
       destinationFile
    );
-   console.log(`downloading draft binary from ${draftDownloadUrl} to ${destinationFile}`);
 
    if (failed(downloadResult)) {
       return {

--- a/src/commands/runDraftTool/helper/runDraftHelper.ts
+++ b/src/commands/runDraftTool/helper/runDraftHelper.ts
@@ -58,6 +58,7 @@ export async function ensureDraftBinary(): Promise<Errorable<null>> {
       draftDownloadUrl,
       destinationFile
    );
+   console.log(`downloading draft binary from ${draftDownloadUrl} to ${destinationFile}`);
 
    if (failed(downloadResult)) {
       return {

--- a/src/commands/runDraftTool/runBuildOnAcr.ts
+++ b/src/commands/runDraftTool/runBuildOnAcr.ts
@@ -51,7 +51,8 @@ export async function runBuildAcrImage(
       throw Error('Tag is undefined');
    }
    const {subscriptionId, resourceGroup} = parseAzureResourceId(id);
-   state.setImage(image(registry, repository, tag));
+   state.setImage(image(registry, repository));
+   state.setImageTag(tag);
 
    const generateButton = 'Generate';
    await vscode.window

--- a/src/commands/runDraftTool/runDraftDeployment.ts
+++ b/src/commands/runDraftTool/runDraftDeployment.ts
@@ -58,6 +58,7 @@ interface PromptContext {
    namespace: string;
    newNamespace: boolean;
    image: string;
+   imagetag: string;
    imageOption: imageOption;
    acrSubscription: SubscriptionItem;
    acrResourceGroup: ResourceGroupItem;
@@ -511,7 +512,8 @@ class PromptAcrTag extends AzureWizardPromptStep<WizardContext> {
       if (tag === undefined) {
          throw Error('Tag is undefined');
       }
-      wizardContext.image = image(server, repository, tag);
+      wizardContext.tag = tag;
+      wizardContext.image = image(server, repository);
    }
 
    public shouldPrompt(wizardContext: WizardContext): boolean {

--- a/src/commands/runDraftTool/runDraftDeployment.ts
+++ b/src/commands/runDraftTool/runDraftDeployment.ts
@@ -323,6 +323,7 @@ class PromptImage extends AzureWizardPromptStep<WizardContext> {
       return wizardContext.imageOption === imageOption.Other;
    }
 }
+
 class PromptImageTag extends AzureWizardPromptStep<WizardContext> {
    public async prompt(wizardContext: WizardContext): Promise<void> {
       wizardContext.imageTag = await wizardContext.ui.showInputBox({

--- a/src/commands/runDraftTool/runDraftDeployment.ts
+++ b/src/commands/runDraftTool/runDraftDeployment.ts
@@ -23,7 +23,7 @@ import {
    getHelm,
    getKubectl
 } from '../../utils/kubernetes';
-import {failed, getAsyncResult} from '../../utils/errorable';
+import {failed, getAsyncResult, succeeded} from '../../utils/errorable';
 import {
    RegistryItem,
    RepositoryItem,
@@ -58,7 +58,7 @@ interface PromptContext {
    namespace: string;
    newNamespace: boolean;
    image: string;
-   imagetag: string;
+   imageTag: string;
    imageOption: imageOption;
    acrSubscription: SubscriptionItem;
    acrResourceGroup: ResourceGroupItem;
@@ -94,10 +94,11 @@ export async function runDraftDeployment(
    const az: AzApi = new Az(getAzCreds);
 
    // Ensure Draft Binary
-   const downloadResult = await longRunning(`Downloading Draft.`, () =>
-      getAsyncResult(ensureDraftBinary())
+   const ensureDraftResult = await longRunning(
+      `Downloading Draft.`,
+      ensureDraftBinary
    );
-   if (!downloadResult) {
+   if (failed(ensureDraftResult)) {
       vscode.window.showErrorMessage('Failed to download Draft');
       return undefined;
    }
@@ -116,7 +117,8 @@ export async function runDraftDeployment(
       port: state.getPort(),
       outputFolder: outputFolder,
       applicationName: applicationNameGuess,
-      image: state.getImage()
+      image: state.getImage(),
+      imageTag: state.getImageTag() || 'latest'
    };
    const promptSteps: IPromptStep[] = [
       new PromptOutputFolder(),
@@ -128,6 +130,7 @@ export async function runDraftDeployment(
       new PromptNewNamespace(),
       new PromptImageOption(completedSteps),
       new PromptImage(),
+      new PromptImageTag(),
       new PromptAcrSubscription(az),
       new PromptAcrResourceGroup(az),
       new PromptAcrRegistry(az),
@@ -314,6 +317,20 @@ class PromptImage extends AzureWizardPromptStep<WizardContext> {
          stepName: 'Image',
          validateInput: ValidateImage,
          value: wizardContext.image
+      });
+   }
+   public shouldPrompt(wizardContext: WizardContext): boolean {
+      return wizardContext.imageOption === imageOption.Other;
+   }
+}
+class PromptImageTag extends AzureWizardPromptStep<WizardContext> {
+   public async prompt(wizardContext: WizardContext): Promise<void> {
+      wizardContext.imageTag = await wizardContext.ui.showInputBox({
+         ignoreFocusOut,
+         prompt: 'Image Tag',
+         stepName: 'Image Tag',
+         validateInput: ValidateImage,
+         value: wizardContext.imageTag
       });
    }
    public shouldPrompt(wizardContext: WizardContext): boolean {
@@ -512,7 +529,7 @@ class PromptAcrTag extends AzureWizardPromptStep<WizardContext> {
       if (tag === undefined) {
          throw Error('Tag is undefined');
       }
-      wizardContext.tag = tag;
+      wizardContext.imageTag = tag;
       wizardContext.image = image(server, repository);
    }
 
@@ -612,13 +629,23 @@ class ExecuteDraft extends AzureWizardExecuteStep<WizardContext> {
          increment?: number | undefined;
       }>
    ): Promise<void> {
-      const {outputFolder, image, applicationName, namespace, port, format} =
-         wizardContext;
+      const {
+         outputFolder,
+         image,
+         imageTag,
+         applicationName,
+         namespace,
+         port,
+         format
+      } = wizardContext;
       if (outputFolder === undefined) {
          throw Error('Output folder is undefined');
       }
       if (image === undefined) {
          throw Error('Image is undefined');
+      }
+      if (imageTag === undefined) {
+         throw Error('Image tag is undefined');
       }
       if (applicationName === undefined) {
          throw Error('Application name is undefined');
@@ -640,7 +667,8 @@ class ExecuteDraft extends AzureWizardExecuteStep<WizardContext> {
          format,
          '',
          namespace,
-         image
+         image,
+         imageTag
       );
       const command = buildCreateCommand(
          outputFolder.fsPath,

--- a/src/commands/runDraftTool/runDraftDockerfile.ts
+++ b/src/commands/runDraftTool/runDraftDockerfile.ts
@@ -230,6 +230,7 @@ class ExecuteDraft extends AzureWizardExecuteStep<WizardContext> {
          '',
          version,
          '',
+         '',
          ''
       );
       const command = buildCreateCommand(

--- a/src/commands/runDraftTool/runDraftDockerfile.ts
+++ b/src/commands/runDraftTool/runDraftDockerfile.ts
@@ -2,11 +2,7 @@ import {longRunning} from '../../utils/host';
 import {Context} from './model/context';
 import * as vscode from 'vscode';
 import {ensureDraftBinary, runDraftCommand} from './helper/runDraftHelper';
-import {
-   DraftLanguage,
-   draftLanguages,
-   getDraftLanguages
-} from './helper/languages';
+import {DraftLanguage, getDraftLanguages} from './helper/languages';
 import {
    AzureWizard,
    AzureWizardExecuteStep,

--- a/src/test/suite/utils/validation.test.ts
+++ b/src/test/suite/utils/validation.test.ts
@@ -67,13 +67,13 @@ suite('Validation Test Suite', () => {
       // some test cases from https://regex101.com/r/a98UqN/1
       const validImages = [
          'alpine',
-         'alpine:latest',
+         'alpine',
          '_/alpine',
-         '_/alpine:latest',
-         'alpine:3.7',
-         'docker.example.com/gmr/alpine:3.7',
-         'docker.example.com:5000/gmr/alpine:latest',
-         'acr/testing:latest'
+         '_/alpine',
+         'alpine',
+         'docker.example.com/gmr/alpine',
+         'docker.example.com:5000/gmr/alpine',
+         'acr/testing'
       ];
       const validatedValid = validImages.map(ValidateImage);
       const invalidImages = [
@@ -82,6 +82,41 @@ suite('Validation Test Suite', () => {
          '/this/has/too/many/slashes'
       ];
       const validatedInvalid = invalidImages.map(ValidateImage);
+
+      (await Promise.all(validatedValid)).forEach((res) => {
+         assert.strictEqual(res, passingTestRet);
+      });
+      (await Promise.all(validatedInvalid)).forEach((res) => {
+         assert.notStrictEqual(res, passingTestRet);
+      });
+   });
+   test('ImageTag', async () => {
+      // some test cases from https://regex101.com/r/a98UqN/1
+      const validTag = [
+         'latest',
+         'my-tag',
+         'my-tag-1.0',
+         'allow_underscores',
+         'allow--double--hyphens',
+         'allow__double__underscores',
+         'allow.periods'
+      ];
+      const validatedValid = validTag.map(ValidateImage);
+      const invalidTags = [
+         '_no-leading-underscore',
+         'no-trailing-underscore_',
+         '-no-leading-hyphen',
+         '--no-leading-double-hyphen',
+         'no-trailing-hyphen-',
+         'no-trailing-double-hyphen--',
+         '.no-leading-period',
+         'no-trailing-period.',
+         '$@%#$%#thisisinvalid',
+         'no/slashes',
+         'no spaces',
+         'no:colons:here'
+      ];
+      const validatedInvalid = invalidTags.map(ValidateImage);
 
       (await Promise.all(validatedValid)).forEach((res) => {
          assert.strictEqual(res, passingTestRet);

--- a/src/test/suite/utils/validation.test.ts
+++ b/src/test/suite/utils/validation.test.ts
@@ -82,7 +82,8 @@ suite('Validation Test Suite', () => {
       const invalidImages = [
          'invalid image',
          '$@%#$%#thisisinvalid',
-         '/this/has/too/many/slashes'
+         '/this/has/too/many/slashes',
+         'no:tag'
       ];
       const validatedInvalid = invalidImages.map(async (word: string) => {
          return [word, await ValidateImage(word)];

--- a/src/test/suite/utils/validation.test.ts
+++ b/src/test/suite/utils/validation.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import {
    ValidateImage,
+   ValidateImageTag,
    ValidatePort,
    ValidateRfc1123
 } from '../../../utils/validation';
@@ -75,24 +76,36 @@ suite('Validation Test Suite', () => {
          'docker.example.com:5000/gmr/alpine',
          'acr/testing'
       ];
-      const validatedValid = validImages.map(ValidateImage);
+      const validatedValid = validImages.map(async (word: string) => {
+         return [word, await ValidateImage(word)];
+      });
       const invalidImages = [
          'invalid image',
          '$@%#$%#thisisinvalid',
          '/this/has/too/many/slashes'
       ];
-      const validatedInvalid = invalidImages.map(ValidateImage);
-
-      (await Promise.all(validatedValid)).forEach((res) => {
-         assert.strictEqual(res, passingTestRet);
+      const validatedInvalid = invalidImages.map(async (word: string) => {
+         return [word, await ValidateImage(word)];
       });
-      (await Promise.all(validatedInvalid)).forEach((res) => {
-         assert.notStrictEqual(res, passingTestRet);
+
+      (await Promise.all(validatedValid)).forEach(([word, res]) => {
+         assert.strictEqual(
+            res,
+            passingTestRet,
+            `Expected ${word} to be valid image`
+         );
+      });
+      (await Promise.all(validatedInvalid)).forEach(([word, res]) => {
+         assert.notStrictEqual(
+            res,
+            passingTestRet,
+            `Expected ${word} to be invalid image`
+         );
       });
    });
    test('ImageTag', async () => {
       // some test cases from https://regex101.com/r/a98UqN/1
-      const validTag = [
+      const validTags = [
          'latest',
          'my-tag',
          'my-tag-1.0',
@@ -101,7 +114,10 @@ suite('Validation Test Suite', () => {
          'allow__double__underscores',
          'allow.periods'
       ];
-      const validatedValid = validTag.map(ValidateImage);
+      const validatedValid = validTags.map(async (word) => [
+         word,
+         await ValidateImageTag(word)
+      ]);
       const invalidTags = [
          '_no-leading-underscore',
          'no-trailing-underscore_',
@@ -116,13 +132,23 @@ suite('Validation Test Suite', () => {
          'no spaces',
          'no:colons:here'
       ];
-      const validatedInvalid = invalidTags.map(ValidateImage);
-
-      (await Promise.all(validatedValid)).forEach((res) => {
-         assert.strictEqual(res, passingTestRet);
+      const validatedInvalid = invalidTags.map(async (word) => {
+         return [word, await ValidateImageTag(word)];
       });
-      (await Promise.all(validatedInvalid)).forEach((res) => {
-         assert.notStrictEqual(res, passingTestRet);
+
+      (await Promise.all(validatedValid)).forEach(([word, res]) => {
+         assert.strictEqual(
+            res,
+            passingTestRet,
+            `Expected ${word} to be valid tag`
+         );
+      });
+      (await Promise.all(validatedInvalid)).forEach(([word, res]) => {
+         assert.notStrictEqual(
+            res,
+            passingTestRet,
+            `Expected ${word} to be invalid tag`
+         );
       });
    });
 });

--- a/src/test/suite/utils/validation.test.ts
+++ b/src/test/suite/utils/validation.test.ts
@@ -114,10 +114,19 @@ suite('Validation Test Suite', () => {
          'allow__double__underscores',
          'allow.periods'
       ];
-      const validatedValid = validTags.map(async (word) => [
+
+      const validTagPromises = validTags.map(async (word) => [
          word,
          await ValidateImageTag(word)
       ]);
+      (await Promise.all(validTagPromises)).forEach(([word, res]) => {
+         assert.strictEqual(
+            res,
+            passingTestRet,
+            `Expected ${word} to be valid tag`
+         );
+      });
+
       const invalidTags = [
          '_no-leading-underscore',
          'no-trailing-underscore_',
@@ -132,18 +141,11 @@ suite('Validation Test Suite', () => {
          'no spaces',
          'no:colons:here'
       ];
-      const validatedInvalid = invalidTags.map(async (word) => {
+
+      const invalidTagPromises = invalidTags.map(async (word) => {
          return [word, await ValidateImageTag(word)];
       });
-
-      (await Promise.all(validatedValid)).forEach(([word, res]) => {
-         assert.strictEqual(
-            res,
-            passingTestRet,
-            `Expected ${word} to be valid tag`
-         );
-      });
-      (await Promise.all(validatedInvalid)).forEach(([word, res]) => {
+      (await Promise.all(invalidTagPromises)).forEach(([word, res]) => {
          assert.notStrictEqual(
             res,
             passingTestRet,

--- a/src/utils/acr.ts
+++ b/src/utils/acr.ts
@@ -1,3 +1,3 @@
-export function image(server: string, repository: string, tag: string): string {
-   return `${server}/${repository}:${tag}`;
+export function image(server: string, repository: string): string {
+   return `${server}/${repository}`;
 }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 const keys = [
    'port',
    'image',
+   'imageTag',
    'dockerfile',
    'deploymentFormat',
    'deploymentPath',

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -61,26 +61,28 @@ export const ValidateImage: Validator = async (image: string) => {
 
    return passingTestRet;
 };
-export const ValidateImageTag: Validator = async (image: string) => {
+export const ValidateImageTag: Validator = async (imageTag: string) => {
    await validationSleep();
 
    // TODO: add validation
-   const re = /^(([\w.\-_]{1,127})|)$/;
-   if (!image.match(re)) {
+   const re = /^(([a-z0-9.\-_]{1,127})|)$/;
+   if (!imageTag.match(re)) {
       return 'ImageTag must be a valid image tag';
    }
 
    // Separator rules from https://docs.docker.com/engine/reference/commandline/tag/
    const separators = ['.', '-', '--', '_', '__'];
-   const startsWithSeparator = separators.some((sep) => image.startsWith(sep));
-   const endsWithSeparator = separators.some((sep) => image.endsWith(sep));
+   const startsWithSeparator = separators.some((sep) =>
+      imageTag.startsWith(sep)
+   );
+   const endsWithSeparator = separators.some((sep) => imageTag.endsWith(sep));
    if (startsWithSeparator || endsWithSeparator) {
       return 'ImageTag must not start or end with a separator';
    }
 
    const invalidSeparators = ['..', '___'];
    const containsInvalidSeparator = invalidSeparators.some((sep) =>
-      image.includes(sep)
+      imageTag.includes(sep)
    );
    if (containsInvalidSeparator) {
       return 'ImageTag must not contain invalid separators';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -52,6 +52,7 @@ export const ValidateRfc1123: Validator = async (input: string) => {
 export const ValidateImage: Validator = async (image: string) => {
    await validationSleep();
 
+   // Separator rules from https://docs.docker.com/engine/reference/commandline/tag/
    const re =
       /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))$/;
    if (!image.match(re)) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -52,7 +52,6 @@ export const ValidateRfc1123: Validator = async (input: string) => {
 export const ValidateImage: Validator = async (image: string) => {
    await validationSleep();
 
-   // TODO: add validation
    const re =
       /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))$/;
    if (!image.match(re)) {
@@ -65,7 +64,7 @@ export const ValidateImageTag: Validator = async (imageTag: string) => {
    await validationSleep();
 
    // TODO: add validation
-   const re = /^(([a-z0-9.\-_]{1,127})|)$/;
+   const re = /^(([a-z0-9.\-_]{1,128})|)$/;
    if (!imageTag.match(re)) {
       return 'ImageTag must be a valid image tag';
    }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -54,9 +54,36 @@ export const ValidateImage: Validator = async (image: string) => {
 
    // TODO: add validation
    const re =
-      /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(:([\w.\-_]{1,127})|)$/;
+      /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))$/;
    if (!image.match(re)) {
       return 'Image must be a valid image name';
+   }
+
+   return passingTestRet;
+};
+export const ValidateImageTag: Validator = async (image: string) => {
+   await validationSleep();
+
+   // TODO: add validation
+   const re = /^(([\w.\-_]{1,127})|)$/;
+   if (!image.match(re)) {
+      return 'ImageTag must be a valid image tag';
+   }
+
+   // Separator rules from https://docs.docker.com/engine/reference/commandline/tag/
+   const separators = ['.', '-', '--', '_', '__'];
+   const startsWithSeparator = separators.some((sep) => image.startsWith(sep));
+   const endsWithSeparator = separators.some((sep) => image.endsWith(sep));
+   if (startsWithSeparator || endsWithSeparator) {
+      return 'ImageTag must not start or end with a separator';
+   }
+
+   const invalidSeparators = ['..', '___'];
+   const containsInvalidSeparator = invalidSeparators.some((sep) =>
+      image.includes(sep)
+   );
+   if (containsInvalidSeparator) {
+      return 'ImageTag must not contain invalid separators';
    }
 
    return passingTestRet;


### PR DESCRIPTION
# Description

Bump draft to v0.0.30
Implement the new draft IMAGETAG variable for the create command, instead of appending it to the IMAGENAME variable
This accounts for a breaking change in v0.0.28 https://github.com/Azure/draft/releases/tag/v0.0.28

## Type of change

Please delete options that are not relevant.

-  [x] Bug fix (non-breaking change which fixes an issue)
-  [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a breaking change which will impact consuming tool(s).

-  [x] Existing tests pass

# Checklist:

-  [x] My code follows the style guidelines of this project
-  [x] I have performed a self-review of my code
-  [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
-  [x] My changes generate no new warnings
-  [x] I have added tests that prove my fix is effective or that my feature works
-  [x] New and existing unit tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules
