### PR TITLE
remove other http addon parts

### DIFF
--- a/src/commands/runDraftTool/runDraftIngress.ts
+++ b/src/commands/runDraftTool/runDraftIngress.ts
@@ -606,14 +606,6 @@ class ExecuteUpdateAddOn extends AzureWizardExecuteStep<WizardContext> {
          throw Error('DNS Zone id is undefined');
       }
 
-      if (cluster.managedCluster.addonProfiles === undefined) {
-         cluster.managedCluster.addonProfiles = {};
-      }
-      cluster.managedCluster.addonProfiles.httpApplicationRouting = {
-         // eslint-disable-next-line @typescript-eslint/naming-convention
-         config: {HTTPApplicationRoutingZoneName: dnsZone},
-         enabled: true
-      };
       if (cluster.managedCluster.ingressProfile === undefined) {
          cluster.managedCluster.ingressProfile = {};
       }

--- a/src/commands/runDraftTool/runDraftIngress.ts
+++ b/src/commands/runDraftTool/runDraftIngress.ts
@@ -467,9 +467,6 @@ class ExecuteEnableAddOn extends AzureWizardExecuteStep<WizardContext> {
       if (cluster.managedCluster.addonProfiles === undefined) {
          cluster.managedCluster.addonProfiles = {};
       }
-      cluster.managedCluster.addonProfiles.httpApplicationRouting = {
-         enabled: true
-      };
       cluster.managedCluster.addonProfiles.azureKeyvaultSecretsProvider = {
          config: {enableSecretRotation: 'true'},
          enabled: true


### PR DESCRIPTION
# Description

Removes code related to http routing. The code currently enables both web app routing and http routing which is a bug (though it has never been deployed so it doesn't affect users). This extension should never do anything with httprouting (it's deprecated and replaced by web app routing). This PR cleans up the incorrect httprouting parts.

## Type of change

Please delete options that are not relevant.

-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-  [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

# Checklist:

-  [x] My code follows the style guidelines of this project
-  [x] I have performed a self-review of my code
-  [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
-  [x] My changes generate no new warnings
-  [x] I have added tests that prove my fix is effective or that my feature works
-  [x] New and existing unit tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules
