### PR TITLE
add way to draft k8s resources without local kubeconfig

### DIFF
--- a/src/commands/runDraftTool/helper/runDraftHelper.ts
+++ b/src/commands/runDraftTool/helper/runDraftHelper.ts
@@ -31,7 +31,7 @@ export async function ensureDraftBinary(): Promise<Errorable<null>> {
    if (!latestReleaseTag) {
       return {
          succeeded: false,
-         error: `failed to get latest release tag`
+         error: `Failed to get latest release tag for downloading draft`
       };
    }
 

--- a/src/commands/runDraftTool/runDraftDeployment.ts
+++ b/src/commands/runDraftTool/runDraftDeployment.ts
@@ -93,13 +93,9 @@ export async function runDraftDeployment(
    const az: AzApi = new Az(getAzCreds);
 
    // Ensure Draft Binary
-   const downloadResult = await longRunning(`Downloading Draft.`, () =>
+   await longRunning(`Downloading Draft.`, () =>
       getAsyncResult(ensureDraftBinary())
    );
-   if (!downloadResult) {
-      vscode.window.showErrorMessage('Failed to download Draft');
-      return undefined;
-   }
 
    const workspaceFolders = vscode.workspace.workspaceFolders;
    if (!outputFolder && workspaceFolders && workspaceFolders.length !== 0) {
@@ -134,7 +130,6 @@ export async function runDraftDeployment(
       new PromptAcrTag(az)
    ];
    const executeSteps: IExecuteStep[] = [
-      new ExecuteCreateNamespace(k8s),
       new ExecuteDraft(),
       new ExecuteOpenFiles(),
       new ExecuteSaveState(state),
@@ -225,38 +220,49 @@ class PromptNamespace extends AzureWizardPromptStep<WizardContext> {
    }
 
    public async prompt(wizardContext: WizardContext): Promise<void> {
-      const namespaces = getAsyncResult(this.k8s.listNamespaces());
-      const newOption = 'New Namespace';
-      const getOptions = async (): Promise<vscode.QuickPickItem[]> => {
-         const namespaceOptions: vscode.QuickPickItem[] = (
-            await namespaces
-         ).map((version) => ({
-            label: version.metadata?.name || ''
-         }));
+      try {
+         const namespaces = getAsyncResult(this.k8s.listNamespaces());
+         const newOption = 'New Namespace';
+         const getOptions = async (): Promise<vscode.QuickPickItem[]> => {
+            const namespaceOptions: vscode.QuickPickItem[] = (
+               await namespaces
+            ).map((version) => ({
+               label: version.metadata?.name || ''
+            }));
 
-         return [
-            {label: newOption},
-            {label: '', kind: vscode.QuickPickItemKind.Separator},
-            ...namespaceOptions,
+            return [
+               {label: newOption},
+               {label: '', kind: vscode.QuickPickItemKind.Separator},
+               ...namespaceOptions,
+               {
+                  label: 'Existing namespaces',
+                  kind: vscode.QuickPickItemKind.Separator
+               }
+            ];
+         };
+         const namespacePick = await wizardContext.ui.showQuickPick(
+            getOptions(),
             {
-               label: 'Existing namespaces',
-               kind: vscode.QuickPickItemKind.Separator
+               ignoreFocusOut,
+               stepName: 'Namespace',
+               placeHolder: 'Namespace'
             }
-         ];
-      };
-      const namespacePick = await wizardContext.ui.showQuickPick(getOptions(), {
-         ignoreFocusOut,
-         stepName: 'Namespace',
-         placeHolder: 'Namespace'
-      });
+         );
 
-      if (namespacePick.label === newOption) {
+         if (namespacePick.label === newOption) {
+            wizardContext.newNamespace = true;
+            return;
+         }
+
+         wizardContext.newNamespace = false;
+         wizardContext.namespace = namespacePick.label;
+      } catch (err) {
+         console.error(`Error prompting namespaces: ${err}`);
+
+         // make the user manually enter a namespace
          wizardContext.newNamespace = true;
          return;
       }
-
-      wizardContext.newNamespace = false;
-      wizardContext.namespace = namespacePick.label;
    }
 
    public shouldPrompt(wizardContext: WizardContext): boolean {
@@ -268,8 +274,8 @@ class PromptNewNamespace extends AzureWizardPromptStep<WizardContext> {
    public async prompt(wizardContext: WizardContext): Promise<void> {
       wizardContext.namespace = await wizardContext.ui.showInputBox({
          ignoreFocusOut,
-         prompt: 'New Namespace',
-         stepName: 'New Namespace',
+         prompt: 'Namespace',
+         stepName: 'Namespace',
          validateInput: ValidateRfc1123,
          value: wizardContext.namespace || wizardContext.applicationName // application name is a reasonable autofill guess
       });
@@ -564,39 +570,6 @@ export class PromptPort extends AzureWizardPromptStep<
       wizardContext: IActionContext & Partial<{port: string}>
    ): boolean {
       return !(this.completedSteps.draftDockerfile && !!wizardContext.port);
-   }
-}
-
-class ExecuteCreateNamespace extends AzureWizardExecuteStep<WizardContext> {
-   public priority: number = 1;
-
-   constructor(private k8s: KubernetesApi) {
-      super();
-   }
-
-   public async execute(
-      wizardContext: WizardContext,
-      progress: vscode.Progress<{
-         message?: string | undefined;
-         increment?: number | undefined;
-      }>
-   ): Promise<void> {
-      const {namespace} = wizardContext;
-      if (namespace === undefined) {
-         throw Error('Namespace is undefined');
-      }
-
-      const result = await this.k8s.createNamespace(namespace);
-      if (failed(result)) {
-         throw Error(result.error);
-      }
-   }
-
-   public shouldExecute(wizardContext: WizardContext): boolean {
-      return (
-         !!wizardContext.newNamespace &&
-         wizardContext.format !== DraftFormat.Helm // Draft creates namespace manifest for Helm
-      );
    }
 }
 

--- a/src/commands/runDraftTool/runDraftDockerfile.ts
+++ b/src/commands/runDraftTool/runDraftDockerfile.ts
@@ -46,13 +46,9 @@ export async function runDraftDockerfile(
    const state: StateApi = State.construct(extensionContext);
 
    // Ensure Draft Binary
-   const downloadResult = await longRunning(`Downloading Draft.`, () =>
+   await longRunning(`Downloading Draft.`, () =>
       getAsyncResult(ensureDraftBinary())
    );
-   if (!downloadResult) {
-      vscode.window.showErrorMessage('Failed to download Draft');
-      return undefined;
-   }
 
    const workspaceFolders = vscode.workspace.workspaceFolders;
    if (!sourceCodeFolder && workspaceFolders && workspaceFolders.length !== 0) {

--- a/src/commands/runDraftTool/runDraftIngress.ts
+++ b/src/commands/runDraftTool/runDraftIngress.ts
@@ -69,13 +69,9 @@ export async function runDraftIngress(
    completedSteps: CompletedSteps
 ) {
    // Ensure Draft Binary
-   const downloadResult = await longRunning(`Downloading Draft`, () =>
+   await longRunning(`Downloading Draft`, () =>
       getAsyncResult(ensureDraftBinary())
    );
-   if (!downloadResult) {
-      vscode.window.showErrorMessage('Failed to download Draft');
-      return undefined;
-   }
 
    const az: AzApi = new Az(getAzCreds);
 
@@ -467,9 +463,6 @@ class ExecuteEnableAddOn extends AzureWizardExecuteStep<WizardContext> {
       if (cluster.managedCluster.addonProfiles === undefined) {
          cluster.managedCluster.addonProfiles = {};
       }
-      cluster.managedCluster.addonProfiles.httpApplicationRouting = {
-         enabled: true
-      };
       cluster.managedCluster.addonProfiles.azureKeyvaultSecretsProvider = {
          config: {enableSecretRotation: 'true'},
          enabled: true
@@ -606,14 +599,6 @@ class ExecuteUpdateAddOn extends AzureWizardExecuteStep<WizardContext> {
          throw Error('DNS Zone id is undefined');
       }
 
-      if (cluster.managedCluster.addonProfiles === undefined) {
-         cluster.managedCluster.addonProfiles = {};
-      }
-      cluster.managedCluster.addonProfiles.httpApplicationRouting = {
-         // eslint-disable-next-line @typescript-eslint/naming-convention
-         config: {HTTPApplicationRoutingZoneName: dnsZone},
-         enabled: true
-      };
       if (cluster.managedCluster.ingressProfile === undefined) {
          cluster.managedCluster.ingressProfile = {};
       }


### PR DESCRIPTION
# Description

This fixes issue #83. Without this improvement, users cannot Draft Kubernetes Deployment and Services without a local k8s context (kubeconfig).

This also fixes a bug with #80. 

#80 swaps how ensureDraftBinary works. This was the pattern introduced by that PR

```TypeScript
   const downloadResult = await longRunning(`Downloading Draft.`, () =>
      getAsyncResult(ensureDraftBinary())
   );
   if (!downloadResult) {
      vscode.window.showErrorMessage('Failed to download Draft');
      return undefined;
   }
```
This pattern will enter the`if (!downloadResult)` even when Draft is correctly installed which is not the intent. The reason is ensureDraftBinary() was switched to return an errorable in #80 which `getAsyncResult` will extract the result or throw in the case of error. When ensureDraftBinary() is successful, it [doesn't actually return a result](https://github.com/Azure/aks-devx-tools/blob/main/src/commands/runDraftTool/helper/runDraftHelper.ts#L70). This results in the `if (!downloadResult) {` being inadvertently evaluated as true. 

This is simply fixed by removing the `if (!downloadResult) {` entirely. `getAsyncResult` will throw if `ensureDraftBinary` fails and thrown errors result in an equivalent error message to `vscode.window.showErrorMessage` (throwing is actually better because it also adds a "report error" button to the message).

Fixes #83 

## Type of change

Please delete options that are not relevant.

-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-  [ ] This change requires a documentation update

# How Has This Been Tested?

-  [x] Tested locally

Should be tested by PMs before release. Sometime we need to create full integration tests for this project. https://github.com/redhat-developer/vscode-extension-tester is promising. This is out of scope for this PR, though.

# Checklist:

-  [x] My code follows the style guidelines of this project
-  [x] I have performed a self-review of my code
-  [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
-  [x] My changes generate no new warnings
-  [x] I have added tests that prove my fix is effective or that my feature works
-  [x] New and existing unit tests pass locally with my changes
-  [x] Any dependent changes have been merged and published in downstream modules
